### PR TITLE
use memcached as add-on name

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -1,4 +1,4 @@
-name: ddev-memcached
+name: memcached
 
 pre_install_actions:
 


### PR DESCRIPTION
## The Issue

Most add-ons have a name like "redis", etc. But the "name" in this one is currently "ddev-memcached"

I don't think this matters until DDEV v1.22.0, when the name is important.

## How This PR Solves The Issue

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

