### PR TITLE
⏫ bump github-action-add-on

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,10 @@ env:
   # Allow ddev get to use a github token to prevent rate limiting by tests
   DDEV_GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+# Required permissions for keep-alive, used by ddev/github-action-add-on-test
+permissions:
+  actions: write
+
 jobs:
   tests:
     strategy:
@@ -28,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: ddev/github-action-add-on-test@v1
+    - uses: ddev/github-action-add-on-test@v2
       with:
         ddev_version: ${{ matrix.ddev_version }}
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## The Issue
The keep-alive action creates dummy commit if a repo hasn't updated. These can pollute the git history.

## How This PR Solves The Issue
This PR bumps github-action-add-on to v2.
This prevents the dummy commits created by the keep-alive action.

https://github.com/see https://github.com/ddev/github-action-add-on-test/releases/tag/v2.0.0
## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->


