### PR TITLE
fix: remove obsolete "version"

### DIFF
--- a/docker-compose.memcached.yaml
+++ b/docker-compose.memcached.yaml
@@ -8,8 +8,6 @@
 # 4. Optional: adjust the 'command' line below to change CLI flags sent to
 #    memcached.
 
-version: '3.6'
-
 services:
   memcached:
     container_name: ddev-${DDEV_SITENAME}-memcached


### PR DESCRIPTION
## The Issue

```
ddev start
...
time="2024-05-03T10:15:55+01:00" level=warning msg="/path/to/project/.ddev/docker-compose.memcached.yaml: `version` is obsolete"
```

## How This PR Solves The Issue

Removes `version`.

## Manual Testing Instructions

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Related Issue Link(s)

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->

