### PR TITLE
feat: easy way to change image, update README.md, constraint for v1.24.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,42 @@
-[![tests](https://github.com/ddev/ddev-memcached/actions/workflows/tests.yml/badge.svg)](https://github.com/ddev/ddev-memcached/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2024.svg)
+[![tests](https://github.com/ddev/ddev-memcached/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/ddev/ddev-memcached/actions/workflows/tests.yml?query=branch%3Amain)
+[![last commit](https://img.shields.io/github/last-commit/ddev/ddev-memcached)](https://github.com/ddev/ddev-memcached/commits)
+[![release](https://img.shields.io/github/v/release/ddev/ddev-memcached)](https://github.com/ddev/ddev-memcached/releases/latest)
 
-## What is this?
+# DDEV Memcached
 
-This repository allows you to quickly install Memcached into a [DDEV](https://ddev.readthedocs.io) project using `ddev get ddev/ddev-memcached`.
+## Overview
+
+[Memcached](https://memcached.org/) is a free & open source, high-performance, distributed memory object caching system.
+
+This add-on integrates Memcached into your [DDEV](https://ddev.com/) project.
 
 ## Installation
 
-For DDEV v1.23.5 or above run
-
-```sh
-ddev add-on get ddev/ddev-memcached && ddev restart
+```bash
+ddev add-on get ddev/ddev-memcached
+ddev restart
 ```
 
-For earlier versions of DDEV run
+After installation, make sure to commit the `.ddev` directory to version control.
 
-```sh
-ddev get ddev/ddev-memcached && ddev restart
-```
-
-## Explanation
-
-This Memcached recipe for [DDEV](https://ddev.readthedocs.io) installs a [`.ddev/docker-compose.memcached.yaml`](docker-compose.memcached.yaml) using the `memcached` Docker image.
-
-## Interacting with Memcached
+## Usage
 
 * The Memcached instance will listen on TCP port 11211 (the Memcached default).
 * Configure your application to access Memcached on the host:port `memcached:11211`.
 * To reach the Memcached admin interface, run `ddev ssh` to connect to the web container, then use `nc` or `telnet` to connect to the Memcached container on port 11211, i.e. `nc memcached 11211`. You can then run commands such as `stats` to see usage information. See [cheatsheet](https://lzone.de/cheat-sheet/memcached) for more commands.
+
+## Advanced Customization
+
+To change the docker image:
+
+```bash
+ddev dotenv set .ddev/.env.memcached --memcached-docker-image=memcached:1.6
+ddev add-on get ddev/ddev-memcached
+ddev restart
+```
+
+Make sure to commit the `.ddev/.env.memcached` file to version control.
+
+## Credits
+
+**Maintained by the [DDEV team](https://ddev.com/support-ddev/)**

--- a/docker-compose.memcached.yaml
+++ b/docker-compose.memcached.yaml
@@ -1,17 +1,8 @@
-# DDEV-Local memcached recipe file.
 #ddev-generated
-# To use this in your own project:
-# 1. Copy this file to your project's ".ddev" directory.
-# 2. Launch "ddev start".
-# 3. Configure the project to look for memcached at hostname "memcached" and
-#    port 11211.
-# 4. Optional: adjust the 'command' line below to change CLI flags sent to
-#    memcached.
-
 services:
   memcached:
     container_name: ddev-${DDEV_SITENAME}-memcached
-    image: memcached:1.6
+    image: ${MEMCACHED_DOCKER_IMAGE:-memcached:1.6}
     restart: "no"
     # memcached is available at this port inside the container.
     expose:
@@ -25,4 +16,5 @@ services:
     command: ["-m", "128"]
 
     volumes:
-    - ".:/mnt/ddev_config"
+      - ".:/mnt/ddev_config"
+      - "ddev-global-cache:/mnt/ddev-global-cache"

--- a/install.yaml
+++ b/install.yaml
@@ -1,9 +1,6 @@
 name: memcached
 
-pre_install_actions:
-
-# files and directories listed here are copied into .ddev
 project_files:
-- docker-compose.memcached.yaml
+  - docker-compose.memcached.yaml
 
-post_install_actions:
+ddev_version_constraint: '>= v1.24.3'


### PR DESCRIPTION
## The Issue

Users should be able to set the image in the `.ddev/.env.memcached` file.

## How This PR Solves The Issue

Adds `--memcached-docker-image` flag.
Adds version constraint for v1.24.3.
Updates README.md.

## Manual Testing Instructions

```bash
ddev dotenv set .ddev/.env.memcached --memcached-docker-image=memcached:1.6
ddev add-on get https://github.com/ddev/ddev-memcached/tarball/20250411_stasadev_readme_constraint_docker_image
ddev restart
```

## Automated Testing Overview

<!-- Please describe the tests introduced by this PR, or explain why no tests are needed. -->

## Release/Deployment Notes

<!-- Does this affect anything else or have ramifications for other code? Does anything have to be done on deployment? -->
